### PR TITLE
:memo: Use double quotes in play command example

### DIFF
--- a/install.md
+++ b/install.md
@@ -36,7 +36,7 @@ correctly:
 alda version
 alda doctor
 alda --help
-alda play -c '(tempo! 160) trumpet: (quant 60) f12 b- > d f6 d12 f1'
+alda play -c "(tempo! 160) trumpet: (quant 60) f12 b- > d f6 d12 f1"
 {% endhighlight %}
 
 _If you're having trouble, please don't hesitate to ask for help in the [Alda


### PR DESCRIPTION
the correct thing here imo is to figure out why it doesn't work on windows, but until then the docs should probably be true to reality so users don't think they installed incorrectly 
fixes #25 